### PR TITLE
fix: Remove `canonifyURLs` from config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,6 @@ title: Receptenboek
 theme: gochowdown
 defaultcontentlanguage: nl
 paginate: 20
-canonifyurls: true
 pygmentsstyle: monokai
 pygmentscodefences: true
 pygmentscodefencesguesssyntax: true


### PR DESCRIPTION
`canonifyURLs` breaks the URL to CSS